### PR TITLE
Update download links to fix stuck installation steps

### DIFF
--- a/launch.bat
+++ b/launch.bat
@@ -49,7 +49,7 @@ if not exist "%RESOURCES_DIR%\main.py" (
 REM Install requirements if needed
 if exist "%RESOURCES_DIR%\requirements.txt" (
     echo Installing Python dependencies...
-    python -m pip install -r "%RESOURCES_DIR%\requirements.txt" --user
+    python -m pip install -r "%RESOURCES_DIR%\requirements.txt"
     echo.
 )
 

--- a/launch.command
+++ b/launch.command
@@ -48,7 +48,7 @@ fi
 
 # Install required packages
 echo "Installing required Python packages..."
-python3 -m pip install -q --user -r resources/requirements.txt
+python3 -m pip install -q -r resources/requirements.txt
 
 # Launch the application
 echo "Starting freeMarkable..."

--- a/launch.sh
+++ b/launch.sh
@@ -43,7 +43,7 @@ fi
 # Install requirements if needed
 if [ -f "$RESOURCES_DIR/requirements.txt" ]; then
     echo "Installing Python dependencies..."
-    python3 -m pip install -r "$RESOURCES_DIR/requirements.txt" --user
+    python3 -m pip install -r "$RESOURCES_DIR/requirements.txt"
     echo ""
 fi
 

--- a/resources/remarkable_xovi_installer/config/settings.py
+++ b/resources/remarkable_xovi_installer/config/settings.py
@@ -80,25 +80,25 @@ class DownloadConfig:
         except Exception as e:
             # Fallback to hardcoded URLs if weblist loading fails
             logging.warning(f"Failed to load URLs from weblist, using fallback values: {e}")
-            self.xovi_extensions_url = "https://github.com/asivery/rm-xovi-extensions/releases/download/v12-12082025/extensions-arm32-testing.zip"
-            self.appload_url = "https://github.com/asivery/rm-appload/releases/download/v0.2.4/appload-arm32.zip"
-            self.xovi_binary_url = "https://github.com/asivery/xovi/releases/latest/download/xovi-arm32.so"
-            self.koreader_url = "https://github.com/koreader/koreader/releases/download/v2025.08/koreader-remarkable-v2025.08.zip"
-            self.xovi_tripletap_url = "https://github.com/rmitchellscott/xovi-tripletap/archive/refs/heads/main.zip"
+            self.xovi_extensions_url = "https://github.com/asivery/rm-xovi-extensions/releases/download/v16-14112025/extensions-arm32-testing.zip"
+            self.appload_url = "https://github.com/asivery/rm-appload/releases/download/v0.4.1/appload-arm32.zip"
+            self.xovi_binary_url = "https://github.com/asivery/xovi/releases/download/v0.3.1/xovi-arm32.so"
+            self.koreader_url = "https://github.com/koreader/koreader/releases/download/v2025.10/koreader-remarkable-v2025.10.zip"
+            self.xovi_tripletap_url = "https://github.com/rmitchellscott/xovi-tripletap/archive/refs/tags/v0.3.0.zip"
             
             # Fallback architecture-specific URL mappings
             self._url_mappings = {
                 "arm32": {
-                    "xovi_extensions": "https://github.com/asivery/rm-xovi-extensions/releases/download/v12-12082025/extensions-arm32-testing.zip",
-                    "appload": "https://github.com/asivery/rm-appload/releases/download/v0.2.4/appload-arm32.zip",
-                    "xovi_binary": "https://github.com/asivery/xovi/releases/latest/download/xovi-arm32.so",
-                    "koreader": "https://github.com/koreader/koreader/releases/download/v2025.08/koreader-remarkable-v2025.08.zip"
+                    "xovi_extensions": "https://github.com/asivery/rm-xovi-extensions/releases/download/v16-14112025/extensions-arm32-testing.zip",
+                    "appload": "https://github.com/asivery/rm-appload/releases/download/v0.4.1/appload-arm32.zip",
+                    "xovi_binary": "https://github.com/asivery/xovi/releases/download/v0.3.1/xovi-arm32.so",
+                    "koreader": "https://github.com/koreader/koreader/releases/download/v2025.10/koreader-remarkable-v2025.10.zip"
                 },
                 "aarch64": {
-                    "xovi_extensions": "https://github.com/asivery/rm-xovi-extensions/releases/download/v12-12082025/extensions-aarch64.zip",
-                    "appload": "https://github.com/asivery/rm-appload/releases/download/v0.2.4/appload-aarch64.zip",
-                    "xovi_binary": "https://github.com/asivery/xovi/releases/download/v0.2.2/xovi-aarch64.so",
-                    "koreader": "https://build.koreader.rocks/download/stable/v2025.08/koreader-remarkable-aarch64-v2025.08.zip"
+                    "xovi_extensions": "https://github.com/asivery/rm-xovi-extensions/releases/download/v16-14112025/extensions-aarch64.zip",
+                    "appload": "https://github.com/asivery/rm-appload/releases/download/v0.4.1/appload-aarch64.zip",
+                    "xovi_binary": "https://github.com/asivery/xovi/releases/download/v0.3.1/xovi-aarch64.so",
+                    "koreader": "https://github.com/koreader/koreader/releases/download/v2025.10/koreader-remarkable-aarch64-v2025.10.zip"
                 }
             }
     
@@ -172,7 +172,7 @@ class DownloadConfig:
                 "xovi_extensions": "extensions-arm32-testing.zip",
                 "appload": "appload-arm32.zip",
                 "xovi_binary": "xovi-arm32.so",
-                "koreader": "koreader-remarkable-v2025.08.zip"
+                "koreader": "koreader-remarkable-v2025.10.zip"
             }
         else:
             # 64-bit aarch64 filenames for Paper Pro
@@ -180,7 +180,7 @@ class DownloadConfig:
                 "xovi_extensions": "extensions-aarch64.zip",
                 "appload": "appload-aarch64.zip",
                 "xovi_binary": "xovi-aarch64.so",
-                "koreader": "koreader-remarkable-aarch64-v2025.08.zip"
+                "koreader": "koreader-remarkable-aarch64-v2025.10.zip"
             }
         
         return filename_map.get(component, f"{component}.zip")

--- a/resources/url.weblist
+++ b/resources/url.weblist
@@ -10,17 +10,17 @@ https://python.org
 https://facebook.github.io/watchman/
 
 # ARM32 Architecture URLs
-https://github.com/asivery/rm-xovi-extensions/releases/download/v12-12082025/extensions-arm32-testing.zip
-https://github.com/asivery/rm-appload/releases/download/v0.2.4/appload-arm32.zip
-https://github.com/asivery/xovi/releases/latest/download/xovi-arm32.so
-https://github.com/koreader/koreader/releases/download/v2025.08/koreader-remarkable-v2025.08.zip
+https://github.com/asivery/rm-xovi-extensions/releases/download/v16-14112025/extensions-arm32-testing.zip
+https://github.com/asivery/rm-appload/releases/download/v0.4.1/appload-arm32.zip
+https://github.com/asivery/xovi/releases/download/v0.3.1/xovi-arm32.so
+https://github.com/koreader/koreader/releases/download/v2025.10/koreader-remarkable-v2025.10.zip
 https://github.com/rmitchellscott/xovi-tripletap/archive/refs/heads/main.zip
 
 # AARCH64 Architecture URLs
-https://github.com/asivery/rm-xovi-extensions/releases/download/v12-12082025/extensions-aarch64.zip
-https://github.com/asivery/rm-appload/releases/download/v0.2.4/appload-aarch64.zip
-https://github.com/asivery/xovi/releases/download/v0.2.2/xovi-aarch64.so
-https://build.koreader.rocks/download/stable/v2025.08/koreader-remarkable-aarch64-v2025.08.zip
+https://github.com/asivery/rm-xovi-extensions/releases/download/v16-14112025/extensions-aarch64.zip
+https://github.com/asivery/rm-appload/releases/download/v0.4.1/appload-aarch64.zip
+https://github.com/asivery/xovi/releases/download/v0.3.1/xovi-aarch64.so
+https://github.com/koreader/koreader/releases/download/v2025.10/koreader-remarkable-aarch64-v2025.10.zip
 
 # API URLs (with placeholder format)
 https://api.github.com/repos/{github_repo}/releases/latest


### PR DESCRIPTION
When I tired to follow the steps to perform a full installation, the installer would get stuck (similar to a few issues mentioned).

After updating the download links, I have successfully completed a full installation! And can confirm that after a triple-click of the power button, I can now open AppLoad and start KOReader.

I've also tweaked the launch script to remove the `--user` pip flag, because it seems to conflict with venv. Happy to remove this if the intention is to make the experience more stream-lined.